### PR TITLE
Preventing parameters of ".fetch()" to overwrite currentQuery

### DIFF
--- a/src/baseComponent.js
+++ b/src/baseComponent.js
@@ -370,13 +370,16 @@
 			}
 			//method to set an attribute must be equal to given value
 		this.equalTo = function (attr, value) {
-			if (!this.currentQuery.find)
-				this.currentQuery.find = {}
-			if (typeof attr == "object")
+			if (!this.currentQuery.find) this.currentQuery.find = {}
+
+			if (typeof attr == "object") {
 				for (key in attr) {
 					this.currentQuery.find[key] = attr[key]
-				} else
-					this.currentQuery.find[attr] = value
+				}
+			} else {
+				this.currentQuery.find[attr] = value
+			}
+
 			return this;
 		};
 		//method to limit the results of query

--- a/src/baseComponent.js
+++ b/src/baseComponent.js
@@ -547,7 +547,7 @@
 		// Return a promise. Modify the instance with the data from Stamplay Server
 		this.fetch = function (thisParams) {
 
-				thisParams = thisParams || this.compile();
+				thisParams = thisParams && _.extend(thisParams, this.compile()) || thisParams;
 				var _this = this;
 
 				if (_this.brickId == 'cobject') {


### PR DESCRIPTION
Hey guys!

I was unable to do the retrieve the `posts` I expected of the following operation:

```js
let posts = new Stamplay.Cobject('posts').Collection

posts
  .equalTo('blog', 'blogname')
  .fetch({ populate_owner: true })
  .then(() => {
    // do something!
  })
```

Basically, the SDK was requesting that query to the following address:

> https://myapp.stamplayapp.com/api/cobject/v1/posts?populate_owner=true

But, what's the point?

The endpoint seemed weird to be, since it wasn't passing the `.equalTo()` condition I previously specified. By then, I decided to investigate and ended figuring out that the problem was that the parameters of the `.fetch()` method were being overwritten the `currentQuery` mounted by the `.compile()` method, which is the responsible for creating recursively the parameters specified by methods like the `.equalTo()`. In others word, if you are passing any parameter to `.fetch()` method, such as `{ populate: true }`, your filtering breaks and priorize any `.fetch()` argument.

With this PR, the final endpoint of that same query is:

> https://myapp.stamplayapp.com/api/cobject/v1/posts?populate_owner=true&blog=blogname

So, it worked! :smile: And sorry for not writing any test—seems this scenario isn't being covered as far as I could realize. 

Finally, it is backward compatible! :ok_hand: 

_A temporary version of this release I launched [here](//yourjavascript.com/1062645372/stamplay.js) for testing purposes._

Thank you guys! Hope it helps!