### PR TITLE
Adding back composability to the query filtering

### DIFF
--- a/src/baseComponent.js
+++ b/src/baseComponent.js
@@ -547,7 +547,7 @@
 		// Return a promise. Modify the instance with the data from Stamplay Server
 		this.fetch = function (thisParams) {
 
-				thisParams = thisParams && _.extend(thisParams, this.compile()) || thisParams;
+				thisParams = thisParams && _.extend(thisParams, this.compile()) || this.compile();
 				var _this = this;
 
 				if (_this.brickId == 'cobject') {


### PR DESCRIPTION
This will prevent a mistake I made in my last PR that if there are no
parameters to the fetch method, then .equalTo or any other method
responsible for the currentQuery matrix will be ignored. Basically,
currentQuery was only happening if you was passing something to
.fetch() as an argument.

_Sorry for this, guys._