### PR TITLE
Adding empty condition for the password

### DIFF
--- a/src/user.js
+++ b/src/user.js
@@ -47,7 +47,7 @@
 			this.Model.login = function (serviceOrEmail, password) {
 					var _this = this;
 
-					if (password) {
+					if (password || password === '') {
 
 						var data = {
 							email: serviceOrEmail,


### PR DESCRIPTION
Hey guys!

Sometimes the user doesn't fill the `password` input, which means: the user submitted the form, his intention is `POST`ing data to the server, BUT he left the password input as blank. The technical result? An empty string, physically manifestated as `""`.

In other words: there is a password; empty, but it is physically there.

But, what's the issue?

Well, if you submit your form without a password through the Stamplay's standalone log-in mechanism—without being in a third-party service—, you is redirected to `http://domain.com:8090/auth/v1//connect` because of [src/user.js#L75](https://github.com/Stamplay/stamplay-js-sdk/blob/master/src/user.js#L75) (you enter in the `else` statement).

I tried to be the most non-opinionated as possible to do not interfere in the architecture proposed through this major version. Also, feel free to versioning as you want. _Pro tip: retrocompatible!_