### PR TITLE
Added support for TypeScript by including stamplay.d.ts Definition File

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,14 @@
     "name": "Stamplay javascript SDK"
   },
   "main": "dist/stamplay-nodeps.js",
+  "typings": "./types/stamplay",
   "scripts": {
     "test": "mocha-phantomjs ./tests/tests.html"
   },
   "dependencies": {
     "store": "~1.3.17",
-    "q": "1.4.1"
+    "q": "1.4.1",
+    "@types/q": "0.0.32"
   },
   "devDependencies": {
     "grunt": "~0.4.1",

--- a/types/stamplay.d.ts
+++ b/types/stamplay.d.ts
@@ -1,0 +1,233 @@
+/// <reference types="Q" />
+
+export = Stamplay;
+
+export as namespace Stamplay;
+
+declare var Stamplay: Stamplay.StamplayStatic;
+
+declare module Stamplay {
+
+    interface StamplayStatic {
+        /**
+     * Methods for Stamplay Objects management.
+     *
+     */
+        Object(objectName: string): IObject,
+
+        /**
+    * Methods for Stamplay Users management.
+    *
+    */
+        User: IUser,
+
+        /**
+    * Methods for Stamplay Codeblocks management.
+    *
+    */
+        Codeblock(codeblockName: string): ICodeblock,
+
+        /**
+    * Methods for calling Webhooks.
+    *
+    */
+        Webhook(webhookName: string): IWebhook,
+
+        /**
+    * First-class Stripe API interface wrapper.
+    *
+    */
+        Stripe: IStripe,
+
+        /**
+    * Advaced Stamplay Queries.
+    *
+    */
+        Query(resourceName: string, propertyName: string): IQuery,
+
+        /**
+    * Initialiase the Stamplay app with this method.
+    *
+    */
+        init(appId: string, options?: any): void;
+    }
+}
+
+interface IObject {
+
+    save(data: any): Q.Promise<any>;
+    save(data: any, callback?: CallbackType): void;
+
+    get(data: any): Q.Promise<any>;
+    get(data: any, callback?: CallbackType): void;
+
+    getById(id: string, data: any): Q.Promise<any>;
+    getById(id: string, data: any, callback?: CallbackType): void;
+
+    remove(id: string): Q.Promise<any>;
+    remove(id: string, callback?: CallbackType): void;
+
+    update(id: string, data: any): Q.Promise<any>;
+    update(id: string, data: any, callback?: CallbackType): void;
+
+    patch(id: string, data: any): Q.Promise<any>;
+    patch(id: string, data: any, callback?: CallbackType): void;
+
+    findByCurrentUser(attribute?: string, data?: any): Q.Promise<any>;
+    findByCurrentUser(attribute?: string, data?: any, callback?: CallbackType): void;
+
+    upVote(id: string): Q.Promise<any>;
+    upVote(id: string, callback?: CallbackType): void;
+
+    downVote(id: string): Q.Promise<any>;
+    downVote(id: string, callback?: CallbackType): void;
+
+    rate(id: string, rate: number): Q.Promise<any>;
+    rate(id: string, rate: number, callback?: CallbackType): void;
+
+    comment(id: string, text: string): Q.Promise<any>;
+    comment(id: string, text: string, callback?: CallbackType): void;
+
+    push(id: string, attribute: string, data: any): Q.Promise<any>;
+    push(id: string, attribute: string, data: any, callback?: CallbackType): void;
+}
+
+interface IUser {
+
+    save(data: any): Q.Promise<any>;
+    save(data: any, callback?: CallbackType): void;
+
+    get(data: any): Q.Promise<any>;
+    get(data: any, callback?: CallbackType): void;
+
+    getById(id: string, data: any): Q.Promise<any>;
+    getById(id: string, data: any, callback?: CallbackType): void;
+
+    remove(id: string): Q.Promise<any>;
+    remove(id: string, callback?: CallbackType): void;
+
+    update(id: string, data: any): Q.Promise<any>;
+    update(id: string, data: any, callback?: CallbackType): void;
+
+    currentUser(): Q.Promise<any>;
+    currentUser(callback?: CallbackType): void;
+
+    login(data: any): Q.Promise<any>;
+    login(data: any, callback?: CallbackType): void;
+
+    socialLogin(provider: string): Q.Promise<any>;
+    socialLogin(provider: string, callback?: CallbackType): void;
+
+    signup(data: any): Q.Promise<any>;
+    signup(data: any, callback?: CallbackType): void;
+
+    logout(): void
+    logout(async: boolean, callback?: CallbackType): void;
+
+    resetPassword(data: any): Q.Promise<any>;
+    resetPassword(data: any, callback?: CallbackType): void;
+
+    getRoles(): Q.Promise<any>;
+    getRoles(callback?: CallbackType): void;
+
+    getRole(id: string): Q.Promise<any>;
+    getRole(id: string, callback?: CallbackType): void;
+
+    setRole(id: string, roleId: string): Q.Promise<any>;
+    setRole(id: string, roleId: string, callback?: CallbackType): void;
+}
+
+interface ICodeblock {
+
+    post(data: any, params?: any): Q.Promise<any>;
+    post(data: any, params?: any, callback?: CallbackType): void;
+
+    put(data: any, params?: any): Q.Promise<any>;
+    put(data: any, params?: any, callback?: CallbackType): void;
+
+    patch(data: any, params?: any): Q.Promise<any>;
+    patch(data: any, params?: any, callback?: CallbackType): void;
+
+    get(params?: any): Q.Promise<any>;
+    get(params?: any, callback?: CallbackType): void;
+
+    delete(params?: any): Q.Promise<any>;
+    delete(params?: any, callback?: CallbackType): void;
+
+    run(data: any, params?: any): Q.Promise<any>;
+    run(data: any, params?: any, callback?: CallbackType): void;
+
+}
+
+interface IWebhook {
+
+    post(data: any): Q.Promise<any>;
+    post(data: any, callback?: CallbackType): void;
+
+}
+
+interface IStripe {
+
+    charge(userId: string, token: string, amount: string, currency?: string): Q.Promise<any>;
+    charge(userId: string, token: string, amount: string, currency?: string, callback?: CallbackType): void;
+
+    createCreditCard(userId: string, token: string, ): Q.Promise<any>;
+    createCreditCard(userId: string, token: string, callback?: CallbackType): void;
+
+    createCustomer(userId: string): Q.Promise<any>;
+    createCustomer(userId: string, callback?: CallbackType): void;
+
+    createSubscription(userId: string, planId: string, ): Q.Promise<any>;
+    createSubscription(userId: string, planId: string, callback?: CallbackType): void;
+
+    deleteSubscription(userId: string, subscriptionId: string, options?: any): Q.Promise<any>;
+    deleteSubscription(userId: string, subscriptionId: string, options?: any, callback?: CallbackType): void;
+
+    getCreditCard(userId: string): Q.Promise<any>;
+    getCreditCard(userId: string, callback?: CallbackType): void;
+
+    getSubscription(userId: string, subscriptionId: string): Q.Promise<any>;
+    getSubscription(userId: string, subscriptionId: string, callback?: CallbackType): void;
+
+    getSubscriptions(userId: string, options?: any): Q.Promise<any>;
+    getSubscriptions(userId: string, options?: any, callback?: CallbackType): void;
+
+    updateCreditCard(userId: string, token: string): Q.Promise<any>;
+    updateCreditCard(userId: string, token: string, callback?: CallbackType): void;
+
+    updateSubscription(userId: string, subscriptionId: string, options?: any): Q.Promise<any>;
+    updateSubscription(userId: string, subscriptionId: string, options?: any, callback?: CallbackType): void;
+
+}
+
+interface IQuery extends Q.IPromise<any> {
+
+    greaterThan(attr: string, value: any): IQuery
+    greaterThanOrEqual(attr: string, value: any): IQuery
+    lessThan(attr: string, value: any): IQuery
+    lessThanOrEqual(attr: string, value: any): IQuery
+    pagination(page: any, per_page: any): IQuery
+    between(attr: string, value1: any, value2: any): IQuery
+    equalTo(attr: string, value: any): IQuery
+    notEqualTo(attr: string, value: any): IQuery
+    exists(attr: string): IQuery
+    notExists(attr: string): IQuery
+    sortAscending(attr: string): IQuery
+    sortDescending(attr: string): IQuery
+    populate(): IQuery
+    populateOwner(): IQuery
+    select(...attr: string[]): IQuery
+    regex(attr: string, regex: any, options: any): IQuery
+    near(type: any, coordinates: any, maxDistance: any, minDistance?: any): IQuery
+    nearSphere(type: any, coordinates: any, maxDistance: any, minDistance?: any): IQuery
+    geoIntersects(type: any, coordinates: any): IQuery
+    geoWithinGeometry(type: any, coordinates: any): IQuery
+    geoWithinCenterSphere(coordinates: any, radius: any): IQuery
+    or(...query: IQuery[]): IQuery
+    exec(callback?: CallbackType): Q.IPromise<any>
+}
+
+interface CallbackType {
+    (err: any, res: any): any
+}
+

--- a/types/stamplay.tests.ts
+++ b/types/stamplay.tests.ts
@@ -1,0 +1,659 @@
+// This file tests the contract defined by the interfaces in stamplay.d.ts against the examples provided by the Stamplay docs
+// Necessary condition (but not sufficient..) for the definition file to be correct is that these examples can be transpiled to javascript without errors by the TypeScript compiler.
+
+// To run the test, use command "tsc stamplay.tests.ts"
+
+// Note that the below examples are in the same order as they appear on the Stamplay docs website
+
+import * as Stamplay from "./stamplay";
+
+var car = {
+    make: "Volkswagen",
+    model: "Jetta",
+    year: 2013,
+    color: "silver",
+    top_speed: 140
+}
+
+Stamplay.Object("car").save(car)
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+Stamplay.Object("car").get({})
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+var credentials = {
+    email: "user@provider.com",
+    password: "123123"
+};
+
+Stamplay.User.signup(credentials)
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+var credentials = {
+    email: "user@provider.com",
+    password: "123123"
+}
+
+Stamplay.User.login(credentials)
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+Stamplay.Object("movie").get({
+    page: 2,
+    per_page: 30
+}).then(function (res) {
+    // success
+}, function (err) {
+    // error
+})
+
+Stamplay.Object("picture")
+    .get({ status: "published" })
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+Stamplay.Object("movie").get({ sort: "-dt_create" })
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+Stamplay.Object("movie").get({ select: "dt_create,owner,title" })
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+Stamplay.Object("movie")
+    .get({ populate: true })
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+Stamplay.Object("movie")
+    .get({ where: JSON.stringify({ rating: { $gt: 5 } }) })
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+var credentials = {
+    email: "user@stamplay.com",
+    password: "my_password"
+}
+
+Stamplay.User.signup(credentials)
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error  
+    })
+
+var credentials = {
+    email: "user@stamplay.com",
+    password: "my_password"
+}
+
+Stamplay.User.login(credentials)
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error  
+    })
+
+Stamplay.init("APP-ID", {
+    isMobile: true,
+    absoluteUrl: true,
+    autorefreshSocialLogin: false
+})
+
+Stamplay.User.socialLogin("facebook")
+
+var emailAndNewPass = {
+    email: "user@stamplay.com",
+    newPassword: "stamplay_rocks!"
+}
+Stamplay.User.resetPassword(emailAndNewPass)
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+//sync
+Stamplay.User.logout();
+
+//async
+Stamplay.User.logout(true, function (err, res) {
+
+})
+
+Stamplay.User.currentUser()
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+Stamplay.User.get({ _id: "user_id" })
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+Stamplay.User.get({})
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+var query = {
+    name: "John",
+    age: 30
+}
+
+Stamplay.User.get(query)
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+var updatedInfo = {
+    name: "John",
+    age: 30
+}
+
+Stamplay.User.update("user_id", updatedInfo)
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+Stamplay.User.remove("user_id")
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+Stamplay.User.getRoles()
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+Stamplay.User.getRole("role_Id")
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+Stamplay.User.setRole("userId", "role_id")
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+var data = {
+    title: "Hello World",
+    year: 2016
+}
+
+Stamplay.Object("movie").save(data)
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+Stamplay.Object("movie").get({ _id: "object_id" })
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+Stamplay.Object("movie").get({})
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+var query2 = {
+    year: 1998
+}
+
+Stamplay.Object("movie").get(query2)
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+Stamplay.Object("movie").findByCurrentUser('director')
+    .then(function (res) {
+        // Success
+    }, function (err) {
+        // Error
+    })
+
+var data2 = {
+    "title": "Goodbye World"
+}
+
+Stamplay.Object("movie").patch("object_id", data2)
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+var data3 = {
+    "title": "Goodbye World"
+}
+
+Stamplay.Object("movie").update("object_id", data3)
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+Stamplay.Object("movie").remove("object_id")
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+Stamplay.Object("movie").push("object_id", "characters", "57cf08e362641ca813b1ae6c")
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+Stamplay.Object("movie").get({ populate: true })
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+// returns records where the rating is greater than 4
+Stamplay.Query('object', 'movie')
+    .greaterThan('actions.ratings.total', 4)
+    .exec()
+    .then(function () {
+        // success
+    }, function (err) {
+        // error
+    })
+
+// returns records that were created after January 15, 2015
+Stamplay.Query('object', 'movie')
+    .greaterThan('dt_create', "2015-01-15T08:00:00.000Z")
+    .exec()
+    .then(function () {
+        // success
+    }, function (err) {
+        // error
+    })
+
+// returns records with a rating of 4 or greater
+Stamplay.Query('object', 'movie')
+    .greaterThanOrEqual('actions.ratings.total', 4)
+    .exec()
+    .then(function () {
+        // success
+    }, function (err) {
+        // error
+    })
+
+// returns records that were last updated on or after April 11, 2012
+Stamplay.Query('object', 'movie')
+    .greaterThanOrEqual('dt_update', "2012-04-11T07:00:00.000Z")
+    .exec()
+    .then(function () {
+        // success
+    }, function (err) {
+        // error
+    })
+
+
+// returns records with a rating of less than 4
+Stamplay.Query('object', 'movie')
+    .lessThan('actions.ratings.total', 4)
+    .exec()
+    .then(function () {
+        // success
+    }, function (err) {
+        // error
+    })
+
+// returns records that were created before January 15, 2015
+Stamplay.Query('object', 'movie')
+    .lessThan('actions.ratings.total', 4)
+    .exec()
+    .then(function () {
+        // success
+    }, function (err) {
+        // error
+    })
+
+
+// returns records with a rating of 4 or less
+Stamplay.Query('object', 'movie')
+    .lessThanOrEqual('actions.ratings.total', 4)
+    .exec()
+    .then(function () {
+        // success
+    }, function (err) {
+        // error
+    })
+
+// returns records that were last updated on or before April 11, 2012
+Stamplay.Query('object', 'movie')
+    .lessThanOrEqual('dt_update', "2012-04-11T07:00:00.000Z")
+    .exec()
+    .then(function () {
+        // success
+    }, function (err) {
+        // error
+    })
+
+Stamplay.Query("object", "cobject_id")
+    .select("title", "actions.ratings.total")
+    .exec()
+    .then(function () {
+        // success
+    }, function (err) {
+        // error
+    })
+
+// sort by title in ascending order
+Stamplay.Query("object", "cobject_id")
+    .sortAscending("title")
+    .exec()
+    .then(function () {
+        // success
+    }, function (err) {
+        // error
+    })
+
+// sort by title in descending order
+Stamplay.Query("object", "cobject_id")
+    .sortDescending("title")
+    .exec()
+    .then(function () {
+        // success
+    }, function (err) {
+        // error
+    })
+
+Stamplay.Query('object', 'question')
+    .regex('title', '^Star', 'i')
+    .exec()
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+var ratedFourOrMore = Stamplay.Query("object", "movie");
+var titleIsStarWars = Stamplay.Query("object", "movie");
+
+ratedFourOrMore.greaterThanOrEqual("actions.ratings.total", 4);
+titleIsStarWars.equalTo("title", "Star Wars");
+
+var combinedQuery = Stamplay.Query("object", "movie");
+combinedQuery.or(ratedFourOrMore, titleIsStarWars);
+
+combinedQuery.exec()
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+Stamplay.Query("object", "movie")
+    .geoWithinGeometry('Polygon',
+    [
+        [[-70, 40], [-72, 40], [-72, 50], [-70, 50], [-70, 40]]
+    ]).exec()
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+Stamplay.Query("object", "movie")
+    .geoIntersects('Point', [74.0059, 40.7127])
+    .exec()
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+Stamplay.Query("object", "dinners")
+    .near('Point', [74.0059, 40.7127], 500)
+    .exec()
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+Stamplay.Query("object", "dinners")
+    .nearSphere('Point', [74.0059, 40.7127], 1000)
+    .exec()
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+Stamplay.Object("movie").downVote("object_id")
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+Stamplay.Object("movie").upVote("object_id")
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+var txt = "comment text goes here";
+
+Stamplay.Object("movie").comment("object_id", txt)
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+
+Stamplay.Object("movie").rate("object_id", 5)
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+var data4 = { message: "Hello" }
+var params = { name: "Stamplay", bar: "foo" }
+
+//Stamplay.Codeblock("codeblock_name").run() sends a POST request by default
+
+Stamplay.Codeblock("codeblock_name").run(data4, params)
+    .then(function (err) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+var params1 = { name: "Stamplay" }
+//GET
+Stamplay.Codeblock("codeblock_name").get(params1, function (err, res) {
+    // manage the response and the error
+})
+
+//POST
+var data5 = { bodyparam: "Stamplay" }
+
+Stamplay.Codeblock("codeblock_name").post(data5)
+    .then(function (err) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+//PUT
+Stamplay.Codeblock("codeblock_name").put(data)
+    .then(function (err) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+//PATCH
+Stamplay.Codeblock("codeblock_name").patch(data)
+    .then(function (err) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+Stamplay.Webhook("webhook_id")
+    .post({ name: "Johne" })
+    .then(function (res) {
+        // success
+    }, function (err) {
+        // error
+    })
+
+Stamplay.Stripe.createCustomer("userId")
+    .then(function (res) {
+        // success
+    },
+    function (err) {
+        // error
+    })
+
+Stamplay.Stripe.getSubscription("userId",
+    "subscriptionId")
+    .then(function (res) {
+        // success
+    },
+    function (err) {
+        // error
+    })
+
+Stamplay.Stripe.getSubscriptions("userId",
+    { someOption: "value" })
+    .then(function (res) {
+        // success
+    },
+    function (err) {
+        // error
+    })
+
+Stamplay.Stripe.createSubscription("userId",
+    "planId")
+    .then(function (res) {
+        // success
+    },
+    function (err) {
+        // error
+    })
+
+Stamplay.Stripe.updateSubscription("userId", "planId",
+    { plan: "subscription_one" })
+    .then(function (res) {
+        // success
+    },
+    function (err) {
+        // error
+    })
+
+Stamplay.Stripe.deleteSubscription("userId",
+    "planId")
+    .then(function (res) {
+        // success
+    },
+    function (err) {
+        // error
+    })
+
+Stamplay.Stripe.getCreditCard("userId")
+    .then(function (res) {
+        // success
+    },
+    function (err) {
+        // error
+    })
+
+Stamplay.Stripe.createCreditCard("userId",
+    "token")
+    .then(function (res) {
+        // success
+    },
+    function (err) {
+        // error
+    })
+
+Stamplay.Stripe.updateCreditCard("userId",
+    "token")
+    .then(function (res) {
+        // success
+    },
+    function (err) {
+        // error
+    })
+
+Stamplay.Stripe.charge("userId",
+    "token",
+    "amount",
+    "currency")
+    .then(function (res) {
+        // Success
+    },
+    function (err) {
+        // Handle Error
+    });


### PR DESCRIPTION
By including the definition file stamplay.d.ts, it is possible to use the Stamplay library in TypeScript and take advantage of strong types. It is also possible to use the typings file to provide intellisense in plain Javascript.

In order to use the typings file, make sure you have the latest version of TypeScript
`npm install typescript -g`

After installing the stamplay sdk with `npm install stamplay-sdk`:
-  if using **TypeScript**, import the module in your .ts file with
`import * as Stamplay from "stamplay-sdk";`
- if using plain **javascript**, import the typings for intellisense support in your .js file by including the triple-slash directive
`/// <reference types="stamplay-sdk"/>`

This has been tested in Visual Studio Code. 